### PR TITLE
chore(dependency): use git https link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
         'cdispyutils'
     ],
     dependency_links=[
-        "git+ssh://git@github.com/uc-cdis/cdis-python-utils.git#egg=cdispyutils"
+        "git+https://github.com/uc-cdis/cdis-python-utils.git#egg=cdispyutils"
      ],
 )


### PR DESCRIPTION
building image in quay.io current doesn't support ssh connection to git as no ssh key is accessable in the container.
r? @jesuspguofc 