### PR TITLE
fix(dependency): specify version for cdispyutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
         'cdispyutils'
     ],
     dependency_links=[
-        "git+https://github.com/uc-cdis/cdis-python-utils.git#egg=cdispyutils"
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.7#egg=cdispyutils"
      ],
 )


### PR DESCRIPTION
https://github.com/uc-cdis/cdis-python-utils/releases/tag/0.1.7
will follow up with a user-api pr after this is merged
r? @zflamig 