### PR TITLE
Chore/dependancy cdispyutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
         'cdispyutils'
     ],
     dependency_links=[
-        "git+https://github.com/uc-cdis/cdis-python-utils.git@df596aacb96c218b9926c72a80c53a1590f2d910#egg=cdispyutils"
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.1#egg=cdispyutils"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ setup(
     install_requires=[
         'boto==2.46.1',
         'botocore==1.5.35',
-        'requests==2.18.0',
+        'requests==2.18.4',
         's3transfer==0.1.10',
         'jmespath==0.9.2',
         'pbr==2.0.0',
         'cdispyutils'
     ],
     dependency_links=[
-        "git+https://github.com/uc-cdis/cdis-python-utils.git@692b30a06269226015d6d55bddbe75f8dbd26b96#egg=cdispyutils"
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@b4760e4ec05176a23c1a9f0854cdf980a26c9762#egg=cdispyutils"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
         'cdispyutils'
     ],
     dependency_links=[
-        "git+https://github.com/uc-cdis/cdis-python-utils.git@b4760e4ec05176a23c1a9f0854cdf980a26c9762#egg=cdispyutils"
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@df596aacb96c218b9926c72a80c53a1590f2d910#egg=cdispyutils"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ setup(
     install_requires=[
         'boto==2.46.1',
         'botocore==1.5.35',
-        'requests==2.13.0',
+        'requests==2.18.0',
         's3transfer==0.1.10',
         'jmespath==0.9.2',
         'pbr==2.0.0',
         'cdispyutils'
     ],
     dependency_links=[
-        "git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.8#egg=cdispyutils"
-     ],
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@692b30a06269226015d6d55bddbe75f8dbd26b96#egg=cdispyutils"
+    ],
 )


### PR DESCRIPTION
Google libraries in `cirrus` require an updated version of `requests`. cirrus is used in fence allong with storage-client and they require conflicting versions. Update version here.

Original PR that requires updated requests: uc-cdis/fence#27
Related PR in cdispyutils for update: [https://github.com/uc-cdis/cdis-python-utils/pull/19](https://github.com/uc-cdis/cdis-python-utils/pull/19)