### PR TITLE
chore(cirrus): Pull cirrus from PyPI; rm boto.cfg in .travis.yml before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ install:
   - python setup.py install
   - pip install -r dev-requirements.txt
 
+before_script:
+  - sudo rm -f /etc/boto.cfg
+
 script:
   - nosetests -v test/test_cleversafe_api_client.py
   - pytest test/test_google_api_client.py -vv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
+gen3cirrus==0.3.0
 -e git+https://github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
--e git+https://github.com/uc-cdis/cirrus.git@0.0.8#egg=cirrus

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gen3cirrus==0.3.0
 -e git+https://github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
+-e git+https://github.com/uc-cdis/cirrus.git@0.0.8#egg=cirrus

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
         'jmespath==0.9.2',
         'pbr==2.0.0',
         'cdislogging',
-        'cirrus',
+        'gen3cirrus>=0.3.0,<1.0.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
         'jmespath==0.9.2',
         'pbr==2.0.0',
         'cdislogging',
-        'gen3cirrus>=0.3.0,<1.0.0',
+        'cirrus',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
         'jmespath==0.9.2',
         'pbr==2.0.0',
         'cdislogging',
-        'cirrus'
+        'gen3cirrus>=0.3.0,<1.0.0',
     ]
 )


### PR DESCRIPTION
misc: rm /etc/boto.cfg in before_script in .travis.yml per spulec/moto #1771. We were already doing this in (for example) Fence.

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates
- Pull gen3cirrus from PyPI instead of using egg link

### Deployment changes
