### PR TITLE
Accept gen3cirrus >=1.0.0, <3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cdislogging==1.0.0
-gen3cirrus==1.0.0
+cdislogging>=1.0.0,<2.0.0
+gen3cirrus>=1.0.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "s3transfer<0.3.0,>=0.2.0",
         "jmespath==0.9.2",
         "pbr==2.0.0",
-        "cdislogging",
-        "gen3cirrus>=1.0.0,<2.0.0",
+        "cdislogging>=1.0.0,<2.0.0",
+        "gen3cirrus>=1.0.0,<3.0.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         "boto>=2.36.0,<3.0.0",
         "botocore>=1.7,<1.13.0",
+        "urllib3>=1.20,<1.26",  # as required by botocore-1.12.253
         "requests>=2.5.2,<3.0.0",
         "s3transfer<0.3.0,>=0.2.0",
         "jmespath==0.9.2",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "boto>=2.36.0,<3.0.0",
         "botocore>=1.7,<1.13.0",
         "urllib3>=1.20,<1.26",  # as required by botocore-1.12.253
+        "six>=1.13.0",  # as required by google-api-core
         "requests>=2.5.2,<3.0.0",
         "s3transfer<0.3.0,>=0.2.0",
         "jmespath==0.9.2",


### PR DESCRIPTION
To fix `Because storageclient (rev 1.0.1) depends on gen3cirrus (>=1.0.0,<2.0.0) and fence depends on gen3cirrus (^2.0.0), storageclient is forbidden.` in https://github.com/uc-cdis/fence/pull/912

### Dependency updates
- Accept gen3cirrus >=1.0.0, <3.0.0 (the 2.x.x breaking change is not breaking for this library)
- Accept urllib3 >=1.20, <1.26 as required by botocore 1.12.253
- Accept six >=1.13.0 as required by google-api-core
- Accept cdislogging >=1.0.0, <2.0.0 instead of just 1.0.0